### PR TITLE
Add Vercel function configuration for AI SDK routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/**/*.ts": {
+      "maxDuration": 60,
+      "memory": 1024
+    }
+  },
+  "regions": ["sfo1", "iad1"]
+}


### PR DESCRIPTION
## Summary
- add a root-level `vercel.json` to extend serverless function duration and memory for AI SDK API routes
- scope deployments to `sfo1` and `iad1` regions that align with the project’s latency targets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2cad882f483298d74f56ebb6eab0e